### PR TITLE
added prebuild step to delete old dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "main": "index.js",
   "scripts": {
     "algolia": "atomic-algolia",
+    "prebuild": "rm -rf dist",
     "build:css": "postcss build static/style.pcss -c ./tailwind.config.js -o ./public/generated.css",
     "start": "concurrently  \"hugo -w\" \"postcss build static/style.pcss -c ./tailwind.config.js\" \"parcel ./public/index.html\" ",
-    "build": "node misc-scripts/github.js; hugo; parcel build ./public/*.html; node misc-scripts/correct-image-paths.js; npm run algolia;",
+    "build": "npm run prebuild; node misc-scripts/github.js; hugo; parcel build ./public/*.html; node misc-scripts/correct-image-paths.js; npm run algolia;",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "contributors": [


### PR DESCRIPTION
I've altered the build step for Netlify as it appears Parcel doesn't delete old dist files ex: 3 of the same images with different hashes might exist in the dist folder. This might cause our "correct-path" script to find the wrong image path to display on our site since parcel doesn't delete old files unless they have the exact same name or hash.

---